### PR TITLE
[WIP] Fix multi worker and pip installed hdf5plugin

### DIFF
--- a/scripts/pip_blosc_fix.py
+++ b/scripts/pip_blosc_fix.py
@@ -1,0 +1,12 @@
+import os
+
+# Load hdf5plugin first
+import hdf5plugin
+# Direct h5py to the new plugin directory
+os.environ["HDF5_PLUGIN_PATH"] = hdf5plugin.PLUGINS_PATH
+# When h5py loads, it will scrape the new plugin directory
+import h5py
+
+f = h5py.File("/Datasets/DSEC/train_split/interlaken_00_c/events/left/events.h5")
+
+x = f['events/x'][:1000]


### PR DESCRIPTION
I spent some time digging into the issues surrounding two primary problems:

1)  pip having a harder time with the hdf5 plugin. This was ultimately fixed by loading in the correct order and setting an environment variable that h5py looks for.

- pip_blosc_fix.py
  - This file provides a potential fix for
    h5py not scraping the correct directory
    for the plugins. By default it attempts
    to search in the hdf5 default (but this
    may not exist).

2) I was seeing issues with more than one worker. I ran into this before in h5py and it was solved by having the child processes open their own versions of the file.

- dataset/sequence.py
  - fix the issues surrounding single file
    descriptor being inherited by the child
    processes. We wait to open the hdf5 files
    until we know we are in process accessing
    individual items
